### PR TITLE
Fix bug related to NightReader writing of translation to output file

### DIFF
--- a/lib/night_reader.rb
+++ b/lib/night_reader.rb
@@ -1,5 +1,5 @@
 require './lib/translator'
 
 translate_to_alphabet = Translator.new  
-# translate_to_alphabet.translate_and_write_to_output
+translate_to_alphabet.translate_to_alpha_and_write_to_output
 p translate_to_alphabet.terminal_message

--- a/lib/night_writer.rb
+++ b/lib/night_writer.rb
@@ -1,5 +1,5 @@
 require './lib/translator'
 
 translate_to_braille = Translator.new  
-translate_to_braille.translate_and_write_to_output
+translate_to_braille.translate_to_braille_and_write_to_output
 p translate_to_braille.terminal_message

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -116,7 +116,7 @@ class Translator
   end
 
   def translate_to_braille_and_write_to_output
-    @output.write(translate_to_braille(read_input_file))
+    write_to_output(translate_to_braille(read_input_file))
     read_output_file
   end
 
@@ -152,6 +152,6 @@ class Translator
   end
 
   def translate_to_alpha_and_write_to_output
-    @output.write(translate_to_alpha_and_line_wrap(read_input_file))
+    write_to_output(translate_to_alpha_and_line_wrap(read_input_file))
   end
 end

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -26,6 +26,10 @@ class Translator
     @output.write(read_input_file)
   end
 
+  def write_to_output(content)
+    @output.write(content)
+  end
+
   def terminal_message
     "Created '#{@output_path}' containing #{read_input_file.length} characters"
   end
@@ -148,11 +152,10 @@ class Translator
   end
 
   def translate_to_alpha_and_line_wrap(braille)
-    @output.write(translate_to_alpha(braille).scan(/.{1,40}/).join("\n"))
-    read_output_file
+    translate_to_alpha(braille).scan(/.{1,40}/).join("\n")
   end
 
   def translate_to_alpha_and_write_to_output
-
+    @output.write(translate_to_alpha_and_line_wrap(read_input_file))
   end
 end

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -152,6 +152,6 @@ class Translator
   end
 
   def translate_to_alpha_and_write_to_output
-    write_to_output(translate_to_alpha_and_line_wrap(read_input_file))
+    write_to_output(translate_to_alpha_and_line_wrap(read_input_file.gsub("\\n", "\n")))   
   end
 end

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -22,10 +22,6 @@ class Translator
     @output.read
   end
 
-  def write_input_to_output
-    @output.write(read_input_file)
-  end
-
   def write_to_output(content)
     @output.write(content)
   end

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -116,7 +116,7 @@ class Translator
   end
 
   def translate_to_braille_and_write_to_output
-    write_to_output(translate_to_braille(read_input_file))
+    write_to_output(translate_to_braille(read_input_file.gsub("\\n", "")))
     read_output_file
   end
 

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -115,7 +115,7 @@ class Translator
     result
   end
 
-  def translate_and_write_to_output
+  def translate_to_braille_and_write_to_output
     @output.write(translate_to_braille(read_input_file))
     read_output_file
   end
@@ -151,4 +151,6 @@ class Translator
     @output.write(translate_to_alpha(braille).scan(/.{1,40}/).join("\n"))
     read_output_file
   end
+
+  # def tr
 end

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -152,5 +152,7 @@ class Translator
     read_output_file
   end
 
-  # def tr
+  def translate_to_alpha_and_write_to_output
+
+  end
 end

--- a/test/translator_test.rb
+++ b/test/translator_test.rb
@@ -8,10 +8,6 @@ class TranslatorTest < MiniTest::Test
     ARGV.replace ['message.txt', 'braille.txt']
     @translator = Translator.new
     create_reusable_variables_for_testing
-    # @translator.write_to_output("")
-
-    # def write(content)
-    #   File.write(@output_path, content)
   end
 
   def create_reusable_variables_for_testing 
@@ -41,10 +37,8 @@ class TranslatorTest < MiniTest::Test
     assert_instance_of String, @translator.read_input_file
   end
 
-  def test_it_can_write_input_to_output_file
-    @translator.stubs(:read_input_file).returns("hola")
-    @translator.write_input_to_output 
-
+  def test_it_can_write_to_output_file
+    @translator.write_to_output("hola")
     assert_equal "hola", @translator.read_output_file
   end
 

--- a/test/translator_test.rb
+++ b/test/translator_test.rb
@@ -128,7 +128,7 @@ class TranslatorTest < MiniTest::Test
     assert_equal @abcs_alpha_formatted, @translator.translate_to_alpha(@abcs_braille_formatted)
   end
 
-  def test_it_can_translate_to_braille_with_line_wrap_and_write_to_output
+  def test_it_can_translate_to_alpha_with_line_wrap_and_write_to_output
     assert_equal @four_hello_worlds_alpha_formatted, @translator.translate_to_alpha_and_line_wrap(@four_hello_worlds_braille_formatted)
 
     assert_equal @abcs_alpha_formatted, @translator.translate_to_alpha_and_line_wrap(@abcs_braille_formatted)

--- a/test/translator_test.rb
+++ b/test/translator_test.rb
@@ -128,7 +128,14 @@ class TranslatorTest < MiniTest::Test
     assert_equal @abcs_alpha_formatted, @translator.translate_to_alpha(@abcs_braille_formatted)
   end
 
-  def test_it_can_translate_to_alpha_with_line_wrap_and_write_to_output
+  def test_it_can_line_wrap_alpha
+    assert_equal @four_hello_worlds_alpha_formatted, @translator.translate_to_alpha_and_line_wrap(@four_hello_worlds_braille_formatted)
+
+    assert_equal @abcs_alpha_formatted, @translator.translate_to_alpha_and_line_wrap(@abcs_braille_formatted)
+  end
+
+
+  def test_it_can_translate_to_alpha_and_write_to_output
     assert_equal @four_hello_worlds_alpha_formatted, @translator.translate_to_alpha_and_line_wrap(@four_hello_worlds_braille_formatted)
 
     assert_equal @abcs_alpha_formatted, @translator.translate_to_alpha_and_line_wrap(@abcs_braille_formatted)

--- a/test/translator_test.rb
+++ b/test/translator_test.rb
@@ -98,11 +98,11 @@ class TranslatorTest < MiniTest::Test
   def test_it_can_translate_to_braille_and_write_to_output
     @translator.stubs(:read_input_file).returns(@ruby_alpha_formatted)
 
-    assert_equal @ruby_braille_formatted, @translator.translate_and_write_to_output
+    assert_equal @ruby_braille_formatted, @translator.translate_to_braille_and_write_to_output
 
     @translator.stubs(:read_input_file).returns(@four_hello_worlds_alpha_plain)
 
-    assert_equal @four_hello_worlds_braille_formatted, @translator.translate_and_write_to_output
+    assert_equal @four_hello_worlds_braille_formatted, @translator.translate_to_braille_and_write_to_output
   end
 
   # ---- translate braille to alpha ---- 
@@ -136,8 +136,9 @@ class TranslatorTest < MiniTest::Test
 
 
   def test_it_can_translate_to_alpha_and_write_to_output
-    assert_equal @four_hello_worlds_alpha_formatted, @translator.translate_to_alpha_and_line_wrap(@four_hello_worlds_braille_formatted)
+    skip
+    @translator.stubs(:read_input_file).returns(@ruby_braille_formatted)
 
-    assert_equal @abcs_alpha_formatted, @translator.translate_to_alpha_and_line_wrap(@abcs_braille_formatted)
+    assert_equal @ruby_braille_formatted, @translator.test_it_can_translate_to_braille_and_write_to_output
   end
 end

--- a/test/translator_test.rb
+++ b/test/translator_test.rb
@@ -8,6 +8,10 @@ class TranslatorTest < MiniTest::Test
     ARGV.replace ['message.txt', 'braille.txt']
     @translator = Translator.new
     create_reusable_variables_for_testing
+    # @translator.write_to_output("")
+
+    # def write(content)
+    #   File.write(@output_path, content)
   end
 
   def create_reusable_variables_for_testing 
@@ -136,9 +140,10 @@ class TranslatorTest < MiniTest::Test
 
 
   def test_it_can_translate_to_alpha_and_write_to_output
-    skip
     @translator.stubs(:read_input_file).returns(@ruby_braille_formatted)
 
-    assert_equal @ruby_braille_formatted, @translator.test_it_can_translate_to_braille_and_write_to_output
+    @translator.translate_to_alpha_and_write_to_output
+
+    assert_equal @ruby_alpha_formatted, @translator.read_output_file
   end
 end


### PR DESCRIPTION
- Importing of new-lines from txt input file (\n) come in as \\n. I _believe_ ruby adds these as escape characters. Because of this, I subbed them out for \n in reading the braille input. 

- Realized this issue also existed in importing of alphabetic characters with any \n.  Subbed out \n for "".  
  - New lines aren't needed when reading and translating from alphabet characters as the line breaks are added to braille translations later in the process. As opposed to reading of braille, which necessitates that lines stay together in order to properly translate. 

closes #40 
