### PR TITLE
Translation refactor

### DIFF
--- a/lib/file_writer.rb
+++ b/lib/file_writer.rb
@@ -1,5 +1,5 @@
 class FileWriter
-  attr_reader :output
+  attr_reader :output, :output_path
   
   def initialize
     @output_path = ARGV[1]

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -6,8 +6,6 @@ require './lib/cluster'
 class Translator
   def initialize
     @dictionary = Dictionary.new
-    @output_path = ARGV[1]
-    @input_path = ARGV[0]
     @input = FileReader.new
     @output = FileWriter.new
   end
@@ -25,7 +23,7 @@ class Translator
   end
 
   def terminal_message
-    "Created '#{@output_path}' containing #{read_output_file.length} characters"
+    "Created '#{@output.output_path}' containing #{read_output_file.length} characters"
   end
 
    # ---- translate single char ----

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -123,18 +123,18 @@ class Translator
   def collection_of_braille_arrays_by_row(braille) 
     split_into_clusters(braille).reduce({}) do |result, cluster|
         index = 0 
-        strings = []
+        all_strings = []
+        
         (cluster.text.gsub("\n", "").length/6).times do 
-          strings << cluster.text.split("\n").map do |sub_row| 
+          braille_char = []
+          braille_char << cluster.text.split("\n").map do |sub_row| 
             sub_row[index..(index + 1)]
           end.join
+          all_strings << braille_char
           index += 2
         end 
-        string_array = strings.map do |string|
-          array = []
-          array << string
-        end
-      result[cluster.text] = string_array
+        
+      result[cluster.text] = all_strings
       result
     end
   end

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -119,7 +119,6 @@ class Translator
 
   def translate_to_braille_and_write_to_output
     write_to_output(translate_to_braille(read_input_file.gsub("\\n", "")))
-    read_output_file
   end
 
   # ---- translate braille to alpha ----

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -98,16 +98,20 @@ class Translator
     "#{row_1}\n#{row_2}\n#{row_3}" 
   end 
 
+  def last_cluster(alpha)
+    split_into_clusters(alpha).length
+  end
+
   def translate_to_braille(alpha)  
     result = ""
 
     split_into_clusters(alpha).each_with_index do |row, index| 
-      if (index != split_into_clusters(alpha).length - 1) && (split_into_clusters(alpha).length > 1)
-        translation = add_rows_and_columns(row.text)
-        result << "#{translation}\n"
-      else 
+      if index + 1 == last_cluster(alpha)
         translation = add_rows_and_columns(row.text)
         result << translation
+      else 
+        translation = add_rows_and_columns(row.text)
+        result << "#{translation}\n"
       end
     end
     result

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -131,8 +131,8 @@ class Translator
           index += 2
         end 
         string_array = strings.map do |string|
-          a = []
-          a << string
+          array = []
+          array << string
         end
       result[cluster.text] = string_array
       result

--- a/test/translator_test.rb
+++ b/test/translator_test.rb
@@ -103,12 +103,14 @@ class TranslatorTest < MiniTest::Test
 
   def test_it_can_translate_to_braille_and_write_to_output
     @translator.stubs(:read_input_file).returns(@ruby_alpha_formatted)
+    @translator.translate_to_braille_and_write_to_output
 
-    assert_equal @ruby_braille_formatted, @translator.translate_to_braille_and_write_to_output
+    assert_equal @ruby_braille_formatted, @translator.read_output_file
 
     @translator.stubs(:read_input_file).returns(@four_hello_worlds_alpha_plain)
+    @translator.translate_to_braille_and_write_to_output
 
-    assert_equal @four_hello_worlds_braille_formatted, @translator.translate_to_braille_and_write_to_output
+    assert_equal @four_hello_worlds_braille_formatted, @translator.read_output_file
   end
 
   # ---- translate braille to alpha ---- 
@@ -139,7 +141,6 @@ class TranslatorTest < MiniTest::Test
 
   def test_it_can_translate_to_alpha_and_write_to_output
     @translator.stubs(:read_input_file).returns(@ruby_braille_formatted)
-
     @translator.translate_to_alpha_and_write_to_output
 
     assert_equal @ruby_alpha_formatted, @translator.read_output_file

--- a/test/translator_test.rb
+++ b/test/translator_test.rb
@@ -72,6 +72,10 @@ class TranslatorTest < MiniTest::Test
     assert_equal 243, @translator.max_chars_per_cluster(@ruby_braille_formatted)
   end
 
+  def test_it_can_return_last_cluster_number 
+    assert_equal 2, @translator.last_cluster(@four_hello_worlds_alpha_plain)
+  end
+
   def test_it_can_split_into_clusters
     assert_equal 2, @translator.split_into_clusters(@four_hello_worlds_alpha_plain).count
     assert_equal 2, @translator.split_into_clusters(@four_hello_worlds_braille_formatted).count


### PR DESCRIPTION
Various refactoring of Translation methods 
- removed unnecessary initialization of input and output paths 
- created a helper method to determine the num of last cluster in a piece of content 
- translate and write method no longer reads output as well (SRP)  

closes #21 
closes #31 